### PR TITLE
chore: promote spring-boot-rest-prometheus-java11 to version 0.0.1

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: python-31stjan
   values:
   - jx-values.yaml
+- chart: dev/spring-boot-rest-prometheus-java11
+  version: 0.0.1
+  name: spring-boot-rest-prometheus-java11
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote spring-boot-rest-prometheus-java11 to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
