### PR TITLE
chore: promote spring-boot-app-feb9th to version 0.0.1

### DIFF
--- a/config-root/namespaces/jenkins-for-jx/jenkins/templates/tests/jenkins-ui-test-b0ine-pod.yaml
+++ b/config-root/namespaces/jenkins-for-jx/jenkins/templates/tests/jenkins-ui-test-b0ine-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-5jbnn"
+  name: "jenkins-ui-test-b0ine"
   namespace: jenkins-for-jx
   annotations:
     "helm.sh/hook": test-success

--- a/config-root/namespaces/jx-staging/spring-boot-app-feb9th/spring-boot-app-feb9th-ingress.yaml
+++ b/config-root/namespaces/jx-staging/spring-boot-app-feb9th/spring-boot-app-feb9th-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: spring-boot-app-feb9th/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: spring-boot-app-feb9th
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: spring-boot-app-feb9th
+              servicePort: 80
+      host: spring-boot-app-feb9th-jx-staging.devopsnextgenlatestdal13-f3fc6b3f137d049465f1eda82e10db30-0000.us-south.containers.appdomain.cloud

--- a/config-root/namespaces/jx-staging/spring-boot-app-feb9th/spring-boot-app-feb9th-spring-boot-app-feb9th-deploy.yaml
+++ b/config-root/namespaces/jx-staging/spring-boot-app-feb9th/spring-boot-app-feb9th-spring-boot-app-feb9th-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: spring-boot-app-feb9th/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spring-boot-app-feb9th-spring-boot-app-feb9th
+  labels:
+    draft: draft-app
+    chart: "spring-boot-app-feb9th-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: spring-boot-app-feb9th-spring-boot-app-feb9th
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: spring-boot-app-feb9th-spring-boot-app-feb9th
+    spec:
+      serviceAccountName: spring-boot-app-feb9th-spring-boot-app-feb9th
+      containers:
+        - name: spring-boot-app-feb9th
+          image: "ghcr.io/vindhya-mora/spring-boot-app-feb9th:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/spring-boot-app-feb9th/spring-boot-app-feb9th-spring-boot-app-feb9th-sa.yaml
+++ b/config-root/namespaces/jx-staging/spring-boot-app-feb9th/spring-boot-app-feb9th-spring-boot-app-feb9th-sa.yaml
@@ -1,0 +1,8 @@
+# Source: spring-boot-app-feb9th/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spring-boot-app-feb9th-spring-boot-app-feb9th
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/spring-boot-app-feb9th/spring-boot-app-feb9th-svc.yaml
+++ b/config-root/namespaces/jx-staging/spring-boot-app-feb9th/spring-boot-app-feb9th-svc.yaml
@@ -1,0 +1,21 @@
+# Source: spring-boot-app-feb9th/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: spring-boot-app-feb9th
+  labels:
+    chart: "spring-boot-app-feb9th-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: spring-boot-app-feb9th-spring-boot-app-feb9th

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: python-31stjan
   values:
   - jx-values.yaml
+- chart: dev/spring-boot-app-feb9th
+  version: 0.0.1
+  name: spring-boot-app-feb9th
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/spring-boot-app-feb9th
   version: 0.0.1
   name: spring-boot-app-feb9th
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote spring-boot-app-feb9th to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
