### PR TITLE
chore: promote account-ms-feb9th to version 0.0.1

### DIFF
--- a/config-root/namespaces/jenkins-for-jx/jenkins/templates/tests/jenkins-ui-test-o9crg-pod.yaml
+++ b/config-root/namespaces/jenkins-for-jx/jenkins/templates/tests/jenkins-ui-test-o9crg-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-jg1dk"
+  name: "jenkins-ui-test-o9crg"
   namespace: jenkins-for-jx
   annotations:
     "helm.sh/hook": test-success

--- a/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-account-ms-feb9th-deploy.yaml
+++ b/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-account-ms-feb9th-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: account-ms-feb9th/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: account-ms-feb9th-account-ms-feb9th
+  labels:
+    draft: draft-app
+    chart: "account-ms-feb9th-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: account-ms-feb9th-account-ms-feb9th
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: account-ms-feb9th-account-ms-feb9th
+    spec:
+      serviceAccountName: account-ms-feb9th-account-ms-feb9th
+      containers:
+        - name: account-ms-feb9th
+          image: "ghcr.io/vindhya-mora/account-ms-feb9th:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-account-ms-feb9th-sa.yaml
+++ b/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-account-ms-feb9th-sa.yaml
@@ -1,0 +1,8 @@
+# Source: account-ms-feb9th/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: account-ms-feb9th-account-ms-feb9th
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-ingress.yaml
+++ b/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: account-ms-feb9th/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: account-ms-feb9th
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: account-ms-feb9th
+              servicePort: 80
+      host: account-ms-feb9th-jx-staging.devopsnextgenlatestdal13-f3fc6b3f137d049465f1eda82e10db30-0000.us-south.containers.appdomain.cloud

--- a/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-svc.yaml
+++ b/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-svc.yaml
@@ -1,0 +1,21 @@
+# Source: account-ms-feb9th/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: account-ms-feb9th
+  labels:
+    chart: "account-ms-feb9th-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    fabric8.io/expose: "true"
+    fabric8.io/ingress.annotations: 'kubernetes.io/ingress.class: nginx'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: account-ms-feb9th-account-ms-feb9th

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -21,5 +21,7 @@ releases:
 - chart: dev/account-ms-feb9th
   version: 0.0.1
   name: account-ms-feb9th
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -18,5 +18,8 @@ releases:
   name: spring-boot-app-feb9th
   values:
   - jx-values.yaml
+- chart: dev/account-ms-feb9th
+  version: 0.0.1
+  name: account-ms-feb9th
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote account-ms-feb9th to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
