### PR TITLE
chore: promote account-ms-feb9th to version 0.0.2

### DIFF
--- a/config-root/namespaces/jenkins-for-jx/jenkins/templates/tests/jenkins-ui-test-h3j4r-pod.yaml
+++ b/config-root/namespaces/jenkins-for-jx/jenkins/templates/tests/jenkins-ui-test-h3j4r-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-vq0gz"
+  name: "jenkins-ui-test-h3j4r"
   namespace: jenkins-for-jx
   annotations:
     "helm.sh/hook": test-success

--- a/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-0.0.2-release.yaml
+++ b/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-0.0.2-release.yaml
@@ -1,0 +1,59 @@
+# Source: account-ms-feb9th/templates/release.yaml
+apiVersion: jenkins.io/v1
+kind: Release
+metadata:
+  creationTimestamp: "2021-02-10T10:16:17Z"
+  deletionTimestamp: null
+  name: 'account-ms-feb9th-0.0.2'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  commits:
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: release 0.0.1
+      sha: a611eae114f462342877948fb6475581cf0719e5
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: add variables
+      sha: 5d928f390fe23ecbc6bfef600be97cd537261c01
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        fix(plugins): use a better version of maven plugins
+      sha: 6b8f227d8b81f08c4bdeeece434ac6380451333d
+    - author:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      branch: master
+      committer:
+        email: jenkins-x@googlegroups.com
+        name: jenkins-x-bot
+      message: |
+        chore: Jenkins X build pack
+      sha: 27a41dcc329f2d6d36d532a4309418e52262ddd8
+  gitHttpUrl: https://github.com/vindhya-mora/account-ms-feb9th
+  gitOwner: vindhya-mora
+  gitRepository: account-ms-feb9th
+  name: 'account-ms-feb9th'
+  releaseNotesURL: https://github.com/vindhya-mora/account-ms-feb9th/releases/tag/v0.0.2
+  version: v0.0.2
+status: {}

--- a/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-account-ms-feb9th-deploy.yaml
+++ b/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-account-ms-feb9th-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: account-ms-feb9th-account-ms-feb9th
   labels:
     draft: draft-app
-    chart: "account-ms-feb9th-0.0.1"
+    chart: "account-ms-feb9th-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,29 +24,29 @@ spec:
       serviceAccountName: account-ms-feb9th-account-ms-feb9th
       containers:
         - name: account-ms-feb9th
-          image: "ghcr.io/vindhya-mora/account-ms-feb9th:0.0.1"
+          image: "ghcr.io/vindhya-mora/account-ms-feb9th:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - containerPort: 8080
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 8080
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 8080
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
+              #         livenessProbe:
+              #           httpGet:
+              #             path: /
+              #             port: 8080
+              #           initialDelaySeconds: 60
+              #           periodSeconds: 10
+              #           successThreshold: 1
+              #           timeoutSeconds: 1
+              #         readinessProbe:
+              #           httpGet:
+              #             path: /
+              #             port: 8080
+              #           periodSeconds: 10
+              #           successThreshold: 1
+              #           timeoutSeconds: 1
           resources:
             limits:
               cpu: 400m

--- a/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-svc.yaml
+++ b/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: account-ms-feb9th
   labels:
-    chart: "account-ms-feb9th-0.0.1"
+    chart: "account-ms-feb9th-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -19,7 +19,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/account-ms-feb9th
-  version: 0.0.1
+  version: 0.0.2
   name: account-ms-feb9th
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote account-ms-feb9th to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
