### PR TITLE
chore: promote account-ms-feb9th to version 0.0.3

### DIFF
--- a/config-root/namespaces/jenkins-for-jx/jenkins/templates/tests/jenkins-ui-test-vts6n-pod.yaml
+++ b/config-root/namespaces/jenkins-for-jx/jenkins/templates/tests/jenkins-ui-test-vts6n-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-h3j4r"
+  name: "jenkins-ui-test-vts6n"
   namespace: jenkins-for-jx
   annotations:
     "helm.sh/hook": test-success

--- a/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-0.0.3-release.yaml
+++ b/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-0.0.3-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-02-10T10:16:17Z"
+  creationTimestamp: "2021-02-11T10:28:31Z"
   deletionTimestamp: null
-  name: 'account-ms-feb9th-0.0.2'
+  name: 'account-ms-feb9th-0.0.3'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.1
-      sha: a611eae114f462342877948fb6475581cf0719e5
+        chore: release 0.0.2
+      sha: 3fcd48c79c185bc6f756132528e3878440bbd04e
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,31 +29,20 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 5d928f390fe23ecbc6bfef600be97cd537261c01
+      sha: bb2ed365117e0603bf97c55150c1addd701d2e32
     - author:
-        email: jenkins-x@googlegroups.com
-        name: jenkins-x-bot
+        email: 55979118+vindhya-mora@users.noreply.github.com
+        name: vindhya-mora
       branch: master
       committer:
-        email: jenkins-x@googlegroups.com
-        name: jenkins-x-bot
-      message: |
-        fix(plugins): use a better version of maven plugins
-      sha: 6b8f227d8b81f08c4bdeeece434ac6380451333d
-    - author:
-        email: jenkins-x@googlegroups.com
-        name: jenkins-x-bot
-      branch: master
-      committer:
-        email: jenkins-x@googlegroups.com
-        name: jenkins-x-bot
-      message: |
-        chore: Jenkins X build pack
-      sha: 27a41dcc329f2d6d36d532a4309418e52262ddd8
+        email: noreply@github.com
+        name: GitHub
+      message: commented the readiness probe
+      sha: 975821aee78d572bbf22c695239b9dbe053f5081
   gitHttpUrl: https://github.com/vindhya-mora/account-ms-feb9th
   gitOwner: vindhya-mora
   gitRepository: account-ms-feb9th
   name: 'account-ms-feb9th'
-  releaseNotesURL: https://github.com/vindhya-mora/account-ms-feb9th/releases/tag/v0.0.2
-  version: v0.0.2
+  releaseNotesURL: https://github.com/vindhya-mora/account-ms-feb9th/releases/tag/v0.0.3
+  version: v0.0.3
 status: {}

--- a/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-account-ms-feb9th-deploy.yaml
+++ b/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-account-ms-feb9th-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: account-ms-feb9th-account-ms-feb9th
   labels:
     draft: draft-app
-    chart: "account-ms-feb9th-0.0.2"
+    chart: "account-ms-feb9th-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: account-ms-feb9th-account-ms-feb9th
       containers:
         - name: account-ms-feb9th
-          image: "ghcr.io/vindhya-mora/account-ms-feb9th:0.0.2"
+          image: "ghcr.io/vindhya-mora/account-ms-feb9th:0.0.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.2
+              value: 0.0.3
           envFrom: null
           ports:
             - containerPort: 8080

--- a/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-svc.yaml
+++ b/config-root/namespaces/jx-staging/account-ms-feb9th/account-ms-feb9th-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: account-ms-feb9th
   labels:
-    chart: "account-ms-feb9th-0.0.2"
+    chart: "account-ms-feb9th-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     fabric8.io/expose: "true"

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -19,7 +19,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/account-ms-feb9th
-  version: 0.0.2
+  version: 0.0.3
   name: account-ms-feb9th
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote account-ms-feb9th to version 0.0.3

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
